### PR TITLE
Make tests pass

### DIFF
--- a/keypipe/__init__.py
+++ b/keypipe/__init__.py
@@ -8,6 +8,7 @@ import os
 from contexter import Contexter
 
 from . import _aepipe
+from ._aepipe import AEError
 from .serialization import serialize
 from .serialization import deserialize
 

--- a/keypipe/cli.py
+++ b/keypipe/cli.py
@@ -127,7 +127,7 @@ def read_key(argv):
 
     if not module:
         print(
-            "Trying to import the {} provider failed with this exception".format(provider
+            "Trying to import the {} provider failed with this exception".format(provider)
         )
         print(indent(exception), file=sys.stderr)
         return None

--- a/keypipe/managers/keyfile.py
+++ b/keypipe/managers/keyfile.py
@@ -12,7 +12,7 @@ def customize_parser(parser):
 
 def get_keypair(args):
     key = os.urandom(32)
-    os.umask(umask | 0077)
+    os.umask(umask | 0o077)
     with open(args.file, 'wb') as f:
         f.write(key)
     return key, ''

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ from setuptools import find_packages
 install_requires = [
   "cffi>=1.0.0",
   "contexter>=0.1.3",
+  'plumbum',
 ]
 
 if sys.version_info.major < 3:
@@ -17,8 +18,17 @@ setup(
     author='Josh Snyder',
     author_email='josh@code406.com',
     packages=find_packages(),
-    setup_requires=["cffi>=1.0.0"],
+    setup_requires=[
+        'cffi>=1.0.0',
+        'pytest-runner',
+    ],
     install_requires=install_requires,
+    tests_require=[
+        'pytest',
+        # these seems to be optional runtime dependencies, but tests won't pass without them
+        'boto3',
+        'requests',
+    ],
     cffi_modules=['cffi_builders/lib.py:ffi'],
     entry_points=dict(
         console_scripts=[

--- a/test/test_decrypt.py
+++ b/test/test_decrypt.py
@@ -1,8 +1,6 @@
 import pytest
 
-from keypipe import AEError
-from keypipe import unseal
-from keypipe._aepipe import _unseal_unchecked
+from keypipe._aepipe import _unseal_unchecked, AEError, unseal
 
 from test.helpers import *
 

--- a/test/test_encrypt.py
+++ b/test/test_encrypt.py
@@ -1,4 +1,4 @@
-from keypipe import seal
+from keypipe._aepipe import seal
 
 from test.helpers import *
 
@@ -11,7 +11,8 @@ def test_multiblock():
     with aepipe_ctx(docs_key, buf, seal) as p:
         for i in range(128):
             os.write(p, b'\x00' * 8192)
-    open('hi', 'wb').write(buf.getvalue())
+    # instead of following line there should be some check, propably?
+    #open('hi', 'wb').write(buf.getvalue())
 
 def test_gcm13():
     expected = b'\x01' + b'\x00' * 12 + uh('530f8afbc74536b9a963b4f1c4cb738b')


### PR DESCRIPTION
My main concern is for the fact there are two `seal` and two `unseal` functions in codebase. In test files I replaced one with another and it seems to be working better. At least if we define "working better" as passed unit tests ;-)